### PR TITLE
Core refactoring (fixes #46)

### DIFF
--- a/src/main/java/io/github/sskorol/core/DataSupplierAspect.java
+++ b/src/main/java/io/github/sskorol/core/DataSupplierAspect.java
@@ -1,6 +1,7 @@
 package io.github.sskorol.core;
 
 import io.github.sskorol.model.DataSupplierMetaData;
+import lombok.val;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.After;
@@ -25,21 +26,22 @@ public class DataSupplierAspect {
 
     @Before("execution(@org.testng.annotations.DataProvider * io.github.sskorol.core.DataProviderTransformer.*(..))")
     public void beforeDataProviderCall(final JoinPoint joinPoint) {
-        DATA_SUPPLIERS.forEach(ds -> ds.beforeDataPreparation((ITestContext) joinPoint.getArgs()[0],
+        DATA_SUPPLIERS.forEach(dataSupplier -> dataSupplier.beforeDataPreparation((ITestContext) joinPoint.getArgs()[0],
                 (Method) joinPoint.getArgs()[1]));
     }
 
     @After("execution(@org.testng.annotations.DataProvider * io.github.sskorol.core.DataProviderTransformer.*(..))")
     public void afterDataProviderCall(final JoinPoint joinPoint) {
-        DATA_SUPPLIERS.forEach(ds -> ds.afterDataPreparation((ITestContext) joinPoint.getArgs()[0],
+        DATA_SUPPLIERS.forEach(dataSupplier -> dataSupplier.afterDataPreparation((ITestContext) joinPoint.getArgs()[0],
                 (Method) joinPoint.getArgs()[1]));
     }
 
-    @Around("execution(* io.github.sskorol.core.DataProviderTransformer.getMetaData(..))")
+    @SuppressWarnings("FinalLocalVariable")
+    @Around("execution(* io.github.sskorol.core.DataProviderTransformer.getDataSupplierMetaData(..))")
     public DataSupplierMetaData onDataPreparation(final ProceedingJoinPoint joinPoint) throws Throwable {
-        final DataSupplierMetaData metaData = (DataSupplierMetaData) joinPoint.proceed(joinPoint.getArgs());
-        DATA_SUPPLIERS.forEach(ds -> ds.onDataPreparation(metaData));
-        return metaData;
+        val dataSupplierMetaData = (DataSupplierMetaData) joinPoint.proceed(joinPoint.getArgs());
+        DATA_SUPPLIERS.forEach(ds -> ds.onDataPreparation(dataSupplierMetaData));
+        return dataSupplierMetaData;
     }
 
     public static List<DataSupplierInterceptor> getInterceptors() {

--- a/src/main/java/io/github/sskorol/core/DataSupplierInterceptor.java
+++ b/src/main/java/io/github/sskorol/core/DataSupplierInterceptor.java
@@ -21,7 +21,7 @@ public interface DataSupplierInterceptor {
     }
 
     default void onDataPreparation(final DataSupplierMetaData metaData) {
-        // do nothing
+        // not implemented
     }
 
     default Collection<DataSupplierMetaData> getMetaData() {

--- a/src/main/java/io/github/sskorol/utils/ReflectionUtils.java
+++ b/src/main/java/io/github/sskorol/utils/ReflectionUtils.java
@@ -2,15 +2,19 @@ package io.github.sskorol.utils;
 
 import io.github.sskorol.core.DataSupplier;
 import io.vavr.Tuple;
+import io.vavr.Tuple2;
 import io.vavr.control.Try;
 import lombok.SneakyThrows;
 import lombok.val;
 import one.util.streamex.StreamEx;
+import org.testng.annotations.ITestAnnotation;
 
 import java.lang.reflect.Method;
 import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import static java.util.Optional.ofNullable;
 import static org.joor.Reflect.on;
 
 /**
@@ -22,32 +26,43 @@ public final class ReflectionUtils {
         throw new UnsupportedOperationException("Illegal access to private constructor");
     }
 
+    @SuppressWarnings("unchecked")
+    public static Class<?> getDataSupplierClass(final ITestAnnotation annotation, final Class testClass,
+                                                final Method testMethod) {
+        return ofNullable(annotation.getDataProviderClass())
+                .map(dataProviderClass -> (Class) dataProviderClass)
+                .orElseGet(() -> ofNullable(testMethod).map(Method::getDeclaringClass).orElse(testClass));
+    }
+
     @SneakyThrows(NoSuchMethodException.class)
     @SuppressWarnings("FinalLocalVariable")
-    public static Method getMethod(final Class<?> targetClass, final String targetMethodName) {
-        val metaData = StreamEx.of(targetClass.getMethods())
-                               .map(m -> Tuple.of(m, m.getDeclaredAnnotation(DataSupplier.class)))
-                               .filter(t -> Objects.nonNull(t._2)
-                                                    && (t._2.name().equals(targetMethodName)
-                                                    || t._1.getName().equals(targetMethodName)))
-                               .map(t -> Tuple.of(t._1.getName(), t._1.getParameterTypes()))
-                               .findFirst()
-                               .orElseGet(() -> Tuple.of(targetMethodName, new Class<?>[0]));
+    public static Method getDataSupplierMethod(final Class<?> targetClass, final String targetMethodName) {
+        val methodMetaData = StreamEx.of(targetClass.getMethods())
+                                     .map(method -> Tuple.of(method, method.getDeclaredAnnotation(DataSupplier.class)))
+                                     .filter(hasDataSupplierMethod(targetMethodName))
+                                     .map(metaData -> Tuple.of(metaData._1.getName(), metaData._1.getParameterTypes()))
+                                     .findFirst()
+                                     .orElseGet(() -> Tuple.of(targetMethodName, new Class<?>[0]));
 
-        return targetClass.getMethod(metaData._1, metaData._2);
+        return targetClass.getMethod(methodMetaData._1, methodMetaData._2);
     }
 
     public static DataSupplier getDataSupplierAnnotation(final Class<?> targetClass, final String targetMethodName) {
-        return Try.of(() -> getMethod(targetClass, targetMethodName))
-                  .map(m -> m.getDeclaredAnnotation(DataSupplier.class))
+        return Try.of(() -> getDataSupplierMethod(targetClass, targetMethodName))
+                  .map(method -> method.getDeclaredAnnotation(DataSupplier.class))
                   .filter(Objects::nonNull)
                   .getOrElse((DataSupplier) null);
     }
 
-    public static Object invoke(final Method method, final Supplier<Object[]> argsSupplier) {
+    public static Object invokeDataSupplier(final Method method, final Supplier<Object[]> argsSupplier) {
         return on(method.getDeclaringClass())
                 .create()
                 .call(method.getName(), argsSupplier.get())
                 .get();
+    }
+
+    private static Predicate<Tuple2<Method, DataSupplier>> hasDataSupplierMethod(final String targetMethodName) {
+        return metaData -> Objects.nonNull(metaData._2)
+                && (metaData._2.name().equals(targetMethodName) || metaData._1.getName().equals(targetMethodName));
     }
 }

--- a/src/test/java/io/github/sskorol/testcases/ReflectionUtilsTests.java
+++ b/src/test/java/io/github/sskorol/testcases/ReflectionUtilsTests.java
@@ -5,7 +5,7 @@ import io.github.sskorol.datasuppliers.ExternalDataSuppliers;
 import io.github.sskorol.utils.ServiceLoaderUtils;
 import org.testng.annotations.Test;
 
-import static io.github.sskorol.utils.ReflectionUtils.getMethod;
+import static io.github.sskorol.utils.ReflectionUtils.getDataSupplierMethod;
 import static org.assertj.core.api.Assertions.*;
 import static org.joor.Reflect.on;
 
@@ -25,7 +25,7 @@ public class ReflectionUtilsTests {
 
     @Test(expectedExceptions = NoSuchMethodException.class)
     public void shouldThrowAnExceptionOnNonExistingMethodAccess() {
-        getMethod(ExternalDataSuppliers.class, "missingMethodName");
+        getDataSupplierMethod(ExternalDataSuppliers.class, "missingMethodName");
     }
 
     @Test


### PR DESCRIPTION
Methods, variables renaming and splitting to make code more obvious and readable.