### PR TITLE
Revert reflections library

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ configurations {
     
 dependencies {
     agent 'org.aspectj:aspectjweaver:1.9.6'
-    implementation 'io.github.sskorol:test-data-supplier:1.9.3'
+    implementation 'io.github.sskorol:test-data-supplier:1.9.4'
 }
 
 test {
@@ -189,7 +189,7 @@ configurations {
     
 dependencies {
     agent 'org.aspectj:aspectjweaver:1.9.6'
-    implementation 'io.github.sskorol:test-data-supplier:1.9.3'
+    implementation 'io.github.sskorol:test-data-supplier:1.9.4'
 }
     
 compileJava {
@@ -480,7 +480,7 @@ Note that in case if you want to manage **DataProviderTransformer** manually, yo
 
 ```groovy
 dependencies {
-    implementation 'io.github.sskorol:test-data-supplier:1.9.3:spi-off'
+    implementation 'io.github.sskorol:test-data-supplier:1.9.4:spi-off'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,8 @@ dependencies {
     api("one.util:streamex:0.7.3")
     api("io.vavr:vavr:1.0.0-alpha-3")
     api("org.aspectj:aspectjrt:${aspectjVersion}")
-    api("org.reflections:reflections:0.9.12")
+    // Don't update to 0.9.12 due to bugs
+    api("org.reflections:reflections:0.9.11")
     api("org.apache.commons:commons-csv:1.9.0")
     api("com.google.code.gson:gson:2.8.8")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}")

--- a/gradle/maven-publish.gradle
+++ b/gradle/maven-publish.gradle
@@ -23,12 +23,6 @@ release {
     tagTemplate = '${version}'
 }
 
-// Required for publishing to Sonatype
-java {
-    withJavadocJar()
-    withSourcesJar()
-}
-
 jar {
     inputs.property("moduleName", moduleName)
     manifest {
@@ -100,6 +94,12 @@ artifacts {
     archives sourceJar
     archives spiOffJar
     archives javadocJar
+}
+
+// Required for publishing to Sonatype
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 afterEvaluate {


### PR DESCRIPTION
#### Context

Reverting breaking dependencies: seems like the latest reflections library has a bug that prevents subtypes analysis. This update downgrades to a stable version.

Fixes #97 