### PR TITLE
Update gson version (patch update)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     // Don't update to 0.9.12 due to bugs
     api("org.reflections:reflections:0.9.11")
     api("org.apache.commons:commons-csv:1.9.0")
-    api("com.google.code.gson:gson:2.8.8")
+    api("com.google.code.gson:gson:2.8.9")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}")
     api("com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
     testImplementation("org.assertj:assertj-core:3.11.1")


### PR DESCRIPTION
As shown [here](https://snyk.io/vuln/maven:com.google.code.gson%3Agson), there was recently a vulnerability detected for `gson:2.8.8` and there is already a new release with the fix https://mvnrepository.com/artifact/com.google.code.gson/gson/2.8.9

(Note: I've used github.dev for creating the PR, so I did not run any test suite before submitting this PR)