### PR TITLE
Fix wrong error messages in data readers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.0.0-SNAPSHOT
+version=1.9.6
 systemProp.sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/jacoco.xml
 systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.organization=sskorol-github

--- a/src/main/java/io/github/sskorol/data/CsvReader.java
+++ b/src/main/java/io/github/sskorol/data/CsvReader.java
@@ -36,7 +36,7 @@ public class CsvReader<T> implements DataReader<T> {
                     .map(args -> onClass(entityClass).create(args).get());
         } catch (IOException ex) {
             throw new IllegalArgumentException(
-                    format("Unable to read JSON data to %s. Check provided path.", entityClass), ex);
+                    format("Unable to read CSV data to %s. Check provided path.", entityClass), ex);
         }
     }
 }

--- a/src/main/java/io/github/sskorol/data/JsonReader.java
+++ b/src/main/java/io/github/sskorol/data/JsonReader.java
@@ -39,7 +39,7 @@ public class JsonReader<T> implements DataReader<T> {
             ));
         } catch (IOException ex) {
             throw new IllegalArgumentException(
-                format("Unable to read CSV data to %s. Check provided path.", entityClass), ex);
+                format("Unable to read JSON data to %s. Check provided path.", entityClass), ex);
         }
     }
 }


### PR DESCRIPTION
#### Context

There was a typo in JSON/CSV readers' exceptions (they were just mixed up). This update introduces a correct naming.

Fixes #104
