### PR TITLE
GH-175: make it possible to supply collections w/o flat-mapping

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,12 +30,13 @@ ToDo
  
 ### Environment
 
-| Component          | Version         |
-|--------------------|-----------------|
-| Test Data Supplier | 2.0.0           |
-| TestNG             | 7.6.0           |
-| Build tool         | gradle@7.4.2    |
-| IDE                | IntelliJ@2022.1 |
+| Component           | Version           |
+|---------------------|-------------------|
+| Test Data Supplier  | 2.2.0             |
+| TestNG              | 7.7.1             |
+| Build tool          | gradle@7.6.0      |
+| IDE                 | IntelliJ@2022.2.3 |
+| JDK                 | temurin-17.0.6    |
 
 ### Can be reproduced via
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -30,12 +30,13 @@ ToDo
  
 ### Environment
 
-| Component          | Version         |
-|--------------------|-----------------|
-| Test Data Supplier | 2.0.0           |
-| TestNG             | 7.6.0           |
-| Build tool         | gradle@7.4.2    |
-| IDE                | IntelliJ@2022.1 |
+| Component          | Version           |
+|--------------------|-------------------|
+| Test Data Supplier | 2.2.0             |
+| TestNG             | 7.7.1             |
+| Build tool         | gradle@7.6.0      |
+| IDE                | IntelliJ@2022.2.3 |
+| JDK                | temurin-17.0.6    |
 
 ### Can be reproduced via
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,3 @@
-[//]: # (
-. Thank you so much for sending us a pull request! 
-.
-. Make sure you have a clear name for your pull request. 
-. To link the request with isses use the following notation: (fixes #123, fixes #321\)
-.
-. An example of good pull request names:
-. - Factory annotation processing support (fixes #123\)
-. - Add an ability to handle external data sources
-)
-
 ### Context
 [//]: # (
 . Describe the problem or feature.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,14 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Build and Test on manual PR
         if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           SONAR_URL: ${{ secrets.SONAR_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: ./gradlew clean sonarqube
+        run: ./gradlew clean sonar
       - name: Built and Test on Depenabot PR
         if: ${{ github.actor == 'dependabot[bot]' }}
         run: ./gradlew clean test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Test Data Supplier Changelog
 
+## 2.2.0
+
+**feat(collections): Supply collections in raw format**
+
+ * GH-175: made it possible to supply collections w/o auto flat-mapping by @sskorol
+ * Updated outdated deps and templates by @sskorol
+
+## 2.1.0
+
+**feat(excel): Implement custom excel files processor**
+
+* GH-130: replaced ZeroCell with custom implementation by @sskorol in #132
+* Automated dependency checks with dependabot by @sskorol
+
 ## 2.0.0
 **feat(java): migrate to Java 17**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,35 @@ clean build publishToMavenLocal --stacktrace
 ```
 
 Note that you must set `SIGNING_KEY_ID`, `SIGNING_KEY` and `SIGNING_PASSWORD` environment variables to publish artifacts
-to Maven local for external testing. You can get these values when you set up `GPG2`.
+to Maven local for external testing. You can get these values when you set up `GPG2` key:
+
+```shell
+gpg2 --full-generate-key
+```
+
+Use 4096-bit RSA encoding. Ensure that email matches your GitHub profile. The passphrase == `SIGNING_PASSWORD`.
+
+Use the following command to get your private `SIGNING_KEY`:
+
+```shell
+gpg2 --export-secret-keys --armor D028459F448C1F19 | cat
+```
+
+You should copy the main output block between newlines and paste it to your `SIGNING_KEY` env var.
+
+`SIGNING_KEY_ID` can be obtained from the following output:
+
+```shell
+gpg2 --list-secret-keys --keyid-format LONG
+```
+
+You'll see something like:
+
+```shell
+sec   rsa4096/XXXXXXXXXXXXXXXXX 2023-01-01 [SC]
+```
+
+Copy the last 8 characters of the key and paste it to `SIGNING_KEY_ID` env var.
 
 ### Test
 
@@ -48,8 +76,7 @@ that the default listening port should be changed to 5005.
 When you start your [test](#test) configuration, you'll enter a "listening for remote connections" mode after
 compilation.
 Then you have to switch to a previously created `Remote JVM Debug` configuration and run it. It'll connect to a
-specified
-port and let you drill into debug mode.
+specified port and let you drill into debug mode.
 
 ## Process
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.sonarqube.gradle.SonarQubeTask
 
 plugins {
     java
@@ -8,11 +7,10 @@ plugins {
     jacoco
     `maven-publish`
     signing
-    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
-    id("org.sonarqube") version "3.4.0.2513"
+    id("io.github.gradle-nexus.publish-plugin") version "1.2.0"
+    id("org.sonarqube") version "4.0.0.2929"
     id("net.researchgate.release") version "3.0.2"
-    id("com.ferranpons.twitterplugin") version "1.1.0"
-    id("com.github.ben-manes.versions") version "0.45.0"
+    id("com.github.ben-manes.versions") version "0.46.0"
 }
 
 group = "io.github.sskorol"
@@ -23,10 +21,10 @@ val gradleScriptDir: String by extra("${rootProject.projectDir}/gradle")
 val projectUrl by extra("https://github.com/sskorol/test-data-supplier")
 val moduleName by extra("io.github.sskorol.testdatasupplier")
 
-val aspectjVersion by extra("1.9.9.1")
-val jacksonVersion by extra("2.13.3")
-val lombokVersion by extra("1.18.24")
-val poiVersion by extra("5.2.2")
+val aspectjVersion by extra("1.9.19")
+val jacksonVersion by extra("2.14.2")
+val lombokVersion by extra("1.18.26")
+val poiVersion by extra("5.2.3")
 
 val agent: Configuration by configurations.creating
 
@@ -71,15 +69,17 @@ dependencies {
     api("io.vavr:vavr:0.10.4")
     api("org.aspectj:aspectjrt:${aspectjVersion}")
     api("org.reflections:reflections:0.10.2")
-    api("org.apache.commons:commons-csv:1.9.0")
+    api("org.apache.commons:commons-csv:1.10.0")
     api("com.google.code.gson:gson:2.10.1")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}")
     api("com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
     api("org.apache.poi:poi:${poiVersion}")
     api("org.apache.poi:poi-ooxml:${poiVersion}")
     api("org.assertj:assertj-core:3.24.2")
+    // Transitive dependency: <=1.33 version has vulnerabilities. Remove when updated by top-level packages.
+    api("org.yaml:snakeyaml:2.0")
     testImplementation("ch.qos.logback:logback-classic:1.4.5")
-    testImplementation("org.apache.logging.log4j:log4j-core:2.19.0")
+    testImplementation("org.apache.logging.log4j:log4j-core:2.20.0")
     testImplementation("org.mockito:mockito-core:5.1.1")
 }
 
@@ -103,7 +103,7 @@ tasks.jacocoTestReport {
     )
 }
 
-sonarqube {
+sonar {
     properties {
         properties(
             hashMapOf<String, String>(
@@ -121,16 +121,14 @@ sonarqube {
     }
 }
 
-tasks.withType<SonarQubeTask> {
-    dependsOn("jacocoTestReport")
-}
+project.tasks["sonar"].dependsOn("jacocoTestReport")
 
 tasks.withType<JacocoReport> {
     dependsOn("build")
 }
 
 tasks.withType(Wrapper::class) {
-    gradleVersion = "7.4.2"
+    gradleVersion = "8.0.1"
 }
 
 tasks.compileJava {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
-version=2.1.0
+version=2.2.0
+systemProp.sonar.host.url=https://sonarcloud.io
+systemProp.sonar.projectKey=io.github.sskorol:test-data-supplier
+systemProp.sonar.organization=sskorol-github

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/github/sskorol/model/DataSupplierMetaData.java
+++ b/src/main/java/io/github/sskorol/model/DataSupplierMetaData.java
@@ -8,7 +8,10 @@ import one.util.streamex.IntStreamEx;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import static io.github.sskorol.utils.ReflectionUtils.invokeDataSupplier;
 import static io.github.sskorol.utils.ReflectionUtils.streamOf;
@@ -37,14 +40,18 @@ public class DataSupplierMetaData {
     }
 
     private List<Object[]> transform() {
-        var data = streamOf(obtainReturnValue()).toList();
+        var returnValue = obtainReturnValue();
+        var data = streamOf(returnValue).toList();
         var indicesList = indicesList(data.size());
         var wrappedReturnValue = EntryStream.of(data).filterKeys(indicesList::contains).values();
 
         if (transpose) {
+            if (returnValue instanceof Collection || returnValue instanceof Map) {
+                return singletonList(flatMap ? wrappedReturnValue.toArray() : new Object[]{returnValue});
+            }
             return singletonList(
                 flatMap
-                ? wrappedReturnValue.flatMap(ReflectionUtils::streamOf).toArray()
+                ? wrappedReturnValue.filter(Objects::nonNull).flatMap(ReflectionUtils::streamOf).toArray()
                 : wrappedReturnValue.toArray()
             );
         }

--- a/src/main/java/io/github/sskorol/utils/ReflectionUtils.java
+++ b/src/main/java/io/github/sskorol/utils/ReflectionUtils.java
@@ -133,7 +133,10 @@ public class ReflectionUtils {
             .filter(dp -> dp != Object.class)
             .orElse((Class) parentClass);
 
-        return Tuple.of(dataSupplierClass, testAnnotation.dataProvider());
+        return Tuple.of(
+            dataSupplierClass,
+            ofNullable(testAnnotation).map(Test::dataProvider).orElse("")
+        );
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -22,7 +22,7 @@ module io.github.sskorol.testdatasupplier {
     requires com.google.gson;
     requires com.fasterxml.jackson.dataformat.yaml;
     requires com.fasterxml.jackson.databind;
-    requires commons.csv;
+    requires org.apache.commons.csv;
     requires org.apache.poi.poi;
     requires org.assertj.core;
     requires static lombok;

--- a/src/test/java/io/github/sskorol/testcases/ArraysDataSupplierTests.java
+++ b/src/test/java/io/github/sskorol/testcases/ArraysDataSupplierTests.java
@@ -23,6 +23,15 @@ public class ArraysDataSupplierTests {
         return new User[] {new User("username", "password"), null};
     }
 
+    @DataSupplier(transpose = true, flatMap = true)
+    public User[] getCustomTransposedExtractedArrayData() {
+        return new User[] {
+            new User("username1", "password1"),
+            new User("username2", "password2"),
+            null
+        };
+    }
+
     @DataSupplier
     public double[] getPrimitiveDoubleArrayData() {
         final double[] doubles = new double[2];
@@ -69,6 +78,11 @@ public class ArraysDataSupplierTests {
 
     @Test(dataProvider = "getCustomArrayData")
     public void supplyCustomArrayData(final User user) {
+        // not implemented
+    }
+
+    @Test(dataProvider = "getCustomTransposedExtractedArrayData")
+    public void supplyCustomTransposedExtractedArrayData(final User user1, final User user2) {
         // not implemented
     }
 

--- a/src/test/java/io/github/sskorol/testcases/CollectionsDataSupplierTests.java
+++ b/src/test/java/io/github/sskorol/testcases/CollectionsDataSupplierTests.java
@@ -20,6 +20,21 @@ public class CollectionsDataSupplierTests {
         return asList("data1", "data2");
     }
 
+    @DataSupplier(transpose = true)
+    public List<String> getTransposedListData() {
+        return asList("data1", "data2");
+    }
+
+    @DataSupplier(flatMap = true)
+    public List<String> getInternallyExtractedListData() {
+        return asList("data1", "data2");
+    }
+
+    @DataSupplier(transpose = true, flatMap = true)
+    public Set<String> getTransposedInternallyExtractedListData() {
+        return StreamEx.of("data1", "data2", "data1").toSet();
+    }
+
     @DataSupplier
     public Map<Integer, String> getCommonMapData() {
         return EntryStream.of(asList("user1", "user2")).toMap();
@@ -40,13 +55,15 @@ public class CollectionsDataSupplierTests {
         return EntryStream.of(asList("user7", "user8")).toMap();
     }
 
-    @DataSupplier(transpose = true)
-    public Set<User> extractCustomListData() {
-        return StreamEx.of(
-            new User("username", "password"),
-            new User("username", "password"),
-            null,
-            null).toSet();
+    @DataSupplier(transpose = true, flatMap = true)
+    public Set<User> extractTransposedSetData() {
+        return StreamEx
+            .of(
+                new User("username", "password"),
+                new User("username", "password"),
+                null,
+                null)
+            .toSet();
     }
 
     @Test(dataProvider = "getCommonListData")
@@ -54,7 +71,22 @@ public class CollectionsDataSupplierTests {
         // not implemented
     }
 
-    @Test(dataProvider = "extractCustomListData")
+    @Test(dataProvider = "getTransposedListData")
+    public void supplyTransposedListData(final List<String> ob) {
+        // not implemented
+    }
+
+    @Test(dataProvider = "getInternallyExtractedListData")
+    public void supplyInternallyExtractedListData(final String ob) {
+        // not implemented
+    }
+
+    @Test(dataProvider = "getTransposedInternallyExtractedListData")
+    public void supplyTransposedInternallyExtractedListData(final String ob1, final String ob2) {
+        // not implemented
+    }
+
+    @Test(dataProvider = "extractTransposedSetData")
     public void supplyCustomListData(final User... users) {
         // not implemented
     }
@@ -75,13 +107,15 @@ public class CollectionsDataSupplierTests {
     }
 
     @Test(dataProvider = "getTransposedMapData")
-    public void supplyTransposedMapData(final Map.Entry<Integer, String> ob1, final Map.Entry<Integer, String> ob2) {
+    public void supplyTransposedMapData(final Map<Integer, String> ob) {
         // not implemented
     }
 
     @Test(dataProvider = "getTransposedInternallyExtractedMapData")
-    public void supplyTransposedInternallyExtractedMapData(final Integer index1, final String ob1,
-                                                           final Integer index2, final String ob2) {
+    public void supplyTransposedInternallyExtractedMapData(
+        final Map.Entry<Integer, String> ob1,
+        final Map.Entry<Integer, String> ob2
+    ) {
         // not implemented
     }
 }

--- a/src/test/java/io/github/sskorol/testcases/DataSupplierTests.java
+++ b/src/test/java/io/github/sskorol/testcases/DataSupplierTests.java
@@ -18,10 +18,12 @@ public class DataSupplierTests extends TestNGRunner {
         var listener = run(ArraysDataSupplierTests.class);
 
         assertThat(listener.getSucceedMethodNames())
-            .hasSize(13)
+            .hasSize(14)
             .containsExactly(
                 "supplyCustomArrayData(User(name=username, password=password))",
                 "supplyCustomArrayData(null)",
+                "supplyCustomTransposedExtractedArrayData(User(name=username1, password=password1),User" +
+                "(name=username2, password=password2))",
                 "supplyExternalArrayData(User(name=user1, password=password1),User(name=user2, password=password2))",
                 "supplyExtractedArrayData(data1,data2)",
                 "supplyNestedArrayData(data3,data3)",
@@ -41,8 +43,8 @@ public class DataSupplierTests extends TestNGRunner {
         var listener = run(CollectionsDataSupplierTests.class);
 
         assertThat(listener.getSucceedMethodNames())
-            .hasSize(11)
-            .containsExactly(
+            .hasSize(15)
+            .containsExactlyInAnyOrder(
                 "supplyCommonListData(data1)",
                 "supplyCommonListData(data2)",
                 "supplyCommonMapData(0=user1)",
@@ -52,8 +54,12 @@ public class DataSupplierTests extends TestNGRunner {
                 "supplyExternalCollectionData(data2)",
                 "supplyInternallyExtractedMapData(0,user3)",
                 "supplyInternallyExtractedMapData(1,user4)",
-                "supplyTransposedInternallyExtractedMapData(0,user7,1,user8)",
-                "supplyTransposedMapData(0=user5,1=user6)"
+                "supplyInternallyExtractedListData(data1)",
+                "supplyInternallyExtractedListData(data2)",
+                "supplyTransposedInternallyExtractedListData(data2,data1)",
+                "supplyTransposedInternallyExtractedMapData(0=user7,1=user8)",
+                "supplyTransposedListData([data1, data2])",
+                "supplyTransposedMapData({0=user5, 1=user6})"
             );
     }
 

--- a/src/test/java/io/github/sskorol/testcases/InjectedArgsDataSupplierTests.java
+++ b/src/test/java/io/github/sskorol/testcases/InjectedArgsDataSupplierTests.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class InjectedArgsDataSupplierTests {
 
-    @DataSupplier(transpose = true)
+    @DataSupplier(transpose = true, flatMap = true)
     public List<String> getFullMetaData(final ITestContext context, final Method method, final ITestNGMethod testNGMethod) {
         return asList(context.getCurrentXmlTest().getName(), method.getName(), testNGMethod.getDescription());
     }


### PR DESCRIPTION
### Context
[//]: # (
. Describe the problem or feature.
)
It was impossible to supply a collection as is into test method. It was automatically expanded. When we don't use `flatMap`, collections should always be injected in the original form w/o elements' extraction. This update adjust the collections processing behavior.

Apart from that, it covers dependency and template updates.

Closes #175 

### Checklist
- [x] Added unit / integration tests
- [x] Added documentation
