### PR TITLE
GH-177: fix artifacts signing task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -342,6 +342,10 @@ tasks.withType(Javadoc::class) {
     opt.addBooleanOption("html5", true)
 }
 
+tasks.withType(Sign::class) {
+    dependsOn("sourceJar")
+}
+
 artifacts {
     add("archives", tasks.getByName("sourceJar"))
     add("archives", tasks.getByName("spiOffJar"))


### PR DESCRIPTION
### Context
[//]: # (
. Describe the problem or feature.
)
It was impossible to sign maven artifacts during publication to sonatype. This fix introduces an explicit dependency on `sourceJar` task.

Closes #177

